### PR TITLE
Debug Logging Toggle 

### DIFF
--- a/src/routes/Connection.ts
+++ b/src/routes/Connection.ts
@@ -1,6 +1,9 @@
 import { type Params } from './Params';
 import { tally } from './CostThreshold';
 
+// remove for debug logging, causes jank
+console.log = function() {}
+
 export enum Mode {
 	Walk,
 	Taxi


### PR DESCRIPTION
Debug logging causes noticable jank of ~400 ms when enabled. Switching it off reduces jank to ~200 ms.